### PR TITLE
Fix display of ‘hash protected’

### DIFF
--- a/Cart_Utils.js
+++ b/Cart_Utils.js
@@ -206,11 +206,11 @@ function openInfo(itemIndex) {
 
         if (item.start != "na") {
             eepromInfo = "EEPROM Usage: start " + item.start + ", end " + item.end;
-            if (item.hash == 0) {
-                eepromInfo = eepromInfo + ", unprotected.";
+            if (item.hash == 1) {
+                eepromInfo = eepromInfo + ", hash protected.";
             }
             else {
-                eepromInfo = eepromInfo + ", hash protected.";
+                eepromInfo = eepromInfo + ", unprotected.";
             }
         }
 


### PR DESCRIPTION
Small change to logic, so when `hash="na"`, it will default to “unprotected”.